### PR TITLE
bigint_sub_internal() : 桁借り処理の不具合修正

### DIFF
--- a/bigint.js
+++ b/bigint.js
@@ -315,6 +315,12 @@ function bigint_sub_internal(x, y) {
         num >>>= 16;
         num &= 1;
     }
+    for (; 0 < num && i < x.len; i++) {
+        num = xds[i] - num;
+        zds[i] = (num & 0xffff);
+        num >>>= 16;
+        num &= 1;
+    }
     var norm = bigint_norm(z);
     return rev ? bigint_neg(norm) : norm;
 }


### PR DESCRIPTION
- 例えば
  bigint('452648541475708928').sub('45298483200000')
  の結果が
  452884717969219584 (0x648f84062c22000)
  になっていた。
  正しくは
  452603242992508928 (0x647f84062c22000)
