### PR TITLE
戻りオブジェクトと負数剰余の改善

### DIFF
--- a/bigint.js
+++ b/bigint.js
@@ -410,9 +410,6 @@ function bigint_divmod(x, y, modulo) {
         z.sign = (x.sign === y.sign);
         if (modulo) {
             if (!x.sign) t2 = -t2;
-            if (x.sign != y.sign) {
-                t2 = t2 + yds[0] * (y.sign ? 1 : -1);
-            }
             return bigint_from_int(t2);
         }
         return bigint_norm(z);
@@ -487,9 +484,6 @@ function bigint_divmod(x, y, modulo) {
         }
         mod.len = ny;
         mod.sign = x.sign;
-        if (x.sign != y.sign) {
-            return bigint_add_internal(mod, y, y.sign);
-        }
         return bigint_norm(mod);
     }
     div = z.clone();

--- a/bigint.js
+++ b/bigint.js
@@ -144,7 +144,6 @@ function bigint_from_int(n) {
     }
     return big;
 }
-var bzero = bigint_from_int(0);
 function bigint_from_string(str, base) {
     var str_i, sign = true, c, len, z, zds, num, i, blen = 1;
     str += '@'; // Terminator;
@@ -238,7 +237,7 @@ function bigint_from_string(str, base) {
 }
 function bigint_from_any(x) {
     if (typeof(x) === 'object') {
-        return (x instanceof BigInt) ? x : bzero;
+        return (x instanceof BigInt) ? x : new BigInt(1, true);
     }
     if (typeof(x) === 'string') {
         return bigint_from_string(x);
@@ -393,7 +392,7 @@ function bigint_divmod(x, y, modulo) {
     yds = y.digits;
     if (ny === 1 && yds[0] === 0) return null;    // Division by zero
     if (nx < ny || nx === ny && x.digits[nx - 1] < y.digits[ny - 1]) {
-        if (modulo) return bigint_norm(x);
+        if (modulo) return x.clone();
         return new BigInt(1, 1);
     }
     xds = x.digits;
@@ -559,6 +558,9 @@ function bigint_number(x) {
 });
 
 Math.BigInt = BigInt;
-bigint = function(a) { return bigint_from_any(a) };
+bigint = function(a) {
+    var x = bigint_from_any(a);
+    return (x === a) ? x = x.clone() : x;
+};
 
 })();


### PR DESCRIPTION
負数を含む剰余の詳細については [負数時の剰余演算子の振る舞い](http://blog.yaju.jp/201010/article_3.html) を参照して下さい。
Divisor方式(Rubyなど)からDividend方式(JavaScriptなど)に変更したので、利用側の修正が必要になる場合があります。
影響度の違いから2つの改善を別々にpull requestした方がよい場合はその旨ご返信下さい。
